### PR TITLE
[RELEASE] GLOB-51 First prod release for Permutive iOS and Catalyst SDK

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Permutive_iOS",
+    platforms: [.macOS(.v10_15), .iOS(.v11)],
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "Permutive_iOS",
+            targets: ["Permutive_iOS"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+    ],
+    targets: [
+        .binaryTarget(name:"Permutive_iOS",
+                      url:"https://storage.googleapis.com/permutive-ios-sdks/swift-sdk/Permutive-iOS-v1.0.0.zip",
+                      checksum: "f9b2bbf9f45ffb8faaafbd9ec5e9f097fea62ac65ec0f64b4fc915801ed8a353")
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Permutive iOS SDK Swift Package
+
+This repo provides SPM support for Permutive iOS and Catalyst SDK.
+
+You can find tvOS support [here](https://github.com/permutive/permutive-tvos-spm).
+
+Please refer to the SDK documentation [here](https://developer.permutive.com/docs/ios).
+Get the latest release notes [here](https://developer.permutive.com/docs/ios-release-notes).
+
+# Use Cocoapods?
+
+Easily include Permutive SDK in your Podfile:
+
+```
+target 'Your Target' do
+    platform :ios, '11.0'
+    pod 'Permutive_iOS', '~> 1.0.0'
+end
+```


### PR DESCRIPTION
# 📰 Release v1.0.0 production release

# 📚 Description
This add support for Swift Package Manager to the iOS and Catalyst Permutive SDK.

You can find Permutive SDK documentation [here](https://developer.permutive.com/docs/ios-sdk).
If you have implemented the beta SDK before, you can find the documentation to safely migrate to production release [here](https://developer.permutive.com/docs/moving-from-the-beta-sdk).

# 🎯 Link to JIRA issue(s)
[JIRA](https://permutive.atlassian.net/browse/GLOB-51)

# 💣 Type of change
- [x] Release

# 🧪 How has this been tested?
- [x] Integration tests
- [x] Unit tests

# 🔮 Future work
N/A