### PR TITLE
Release v2.5.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     ],
     targets: [
         .binaryTarget(name:"Permutive_iOS",
-		url:"https://storage.googleapis.com/permutive-ios-sdks/swift-sdk/Permutive_iOS-v2.5.1.zip",
-		checksum:"0ea92a53e4a508f96e97064b8dc19b5a05884bc74497918b09c1972a33457fbe")
+		url:"https://storage.googleapis.com/permutive-ios-sdks/swift-sdk/Permutive_iOS-v2.5.2.zip",
+		checksum:"52557a4996b0a31e4abb95ccd988b67272859b08e9f8eb63130970ad7cf92779")
     ]
 )

--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ Easily include Permutive SDK in your Podfile:
 ```
 target 'Your Target' do
     platform :ios, '12.0'
-    pod 'Permutive_iOS', '~> 2.5.1'
+    pod 'Permutive_iOS', '~> 2.5.2'
 end
 ```


### PR DESCRIPTION
- Defaults to the Core Engine when no A/B test configuration applies (Fix)
- Persists Core Engine state in file storage instead of UserDefaults to fit within the tvOS UserDefaults size limit (Fix)