### PR TITLE
Update README for v3.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ Easily include Permutive SDK in your Podfile:
 ```
 target 'Your Target' do
     platform :ios, '13.0'
-    pod 'Permutive_iOS', '~> 3.0.1'
+    pod 'Permutive_iOS', '~> 3.0.2'
 end
 ```


### PR DESCRIPTION
Bumps the CocoaPods install example to 3.0.2.